### PR TITLE
small improvements and rename `name/names` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The gem aims to be really simple. If you looking for something more complex I re
 
 [Reddit discussion](https://www.reddit.com/r/ruby/comments/4i5dep/gem_inputs_another_pointless_gem_for_handling/)
 
-```
+```ruby
 require 'inputs'
 
 Inputs.yn('Are you stupid?')

--- a/lib/inputs.rb
+++ b/lib/inputs.rb
@@ -15,6 +15,7 @@ module Inputs
     output question
     _input_evaluator.call.chomp
   end
+  alias_method :name, :text
 
   def self.multiple_text(question)
     output question + " (Comma separated)"
@@ -23,6 +24,7 @@ module Inputs
     output "Okay, got #{texts.count} items."
     texts
   end
+  alias_method :names, :multiple_text
 
   def self.pick(options, question: "Please choose:", option_output_eval: ->(key, option) { "  Press #{key} for \"#{option}\"" })
     option_map = options

--- a/lib/inputs.rb
+++ b/lib/inputs.rb
@@ -7,7 +7,7 @@ module Inputs
       output question + " [y/n]"
       input = _input_evaluator.call
       input = input.chomp
-    end until %w(y n).include?(input.chomp
+    end until %w(y n).include?(input.chomp)
     input == 'y'
   end
 

--- a/lib/inputs.rb
+++ b/lib/inputs.rb
@@ -7,14 +7,8 @@ module Inputs
       output question + " [y/n]"
       input = _input_evaluator.call
       input = input.chomp
-    end until %w(y n).include?(input.chomp)
-
-    case input
-    when 'y'
-      true
-    when 'n'
-      false
-    end
+    end until %w(y n).include?(input.chomp
+    input == 'y'
   end
 
   def self.text(question)

--- a/lib/inputs.rb
+++ b/lib/inputs.rb
@@ -17,20 +17,17 @@ module Inputs
     end
   end
 
-  def self.name(question)
+  def self.text(question)
     output question
-    name = _input_evaluator.call
-    name = name.chomp
-    output name.green
-    name
+    _input_evaluator.call.chomp
   end
 
-  def self.names(question)
+  def self.multiple_text(question)
     output question + " (Comma separated)"
-    names = _input_evaluator.call
-    names = names.chomp.split(',').map(&:strip)
-    output names.join(' & ').green
-    names
+    texts = _input_evaluator.call
+    texts = texts.chomp.split(',').map(&:strip)
+    output "Okay, got #{texts.count} items."
+    texts
   end
 
   def self.pick(options, question: "Please choose:", option_output_eval: ->(key, option) { "  Press #{key} for \"#{option}\"" })


### PR DESCRIPTION
In my opinion the `names` method should be called `text`, because it's just a simple text, which has nothing to do with a name.

You can squash the commits into one to merge them :grin:
